### PR TITLE
Update ubc_paragraph_entities.module

### DIFF
--- a/ubc_paragraph_entities/ubc_paragraph_entities.module
+++ b/ubc_paragraph_entities/ubc_paragraph_entities.module
@@ -17,6 +17,10 @@ function ubc_paragraph_entities_theme_suggestions_paragraph_alter(&$suggestions,
  */
 function ubc_paragraph_entities_theme($existing, $type, $theme, $path) {
   return [
+    // added back in as suggestion only
+    'ubc_paragraph__card' => [
+      'base hook' => 'paragraph'
+    ],
     'ubc_paragraph__card_group' => [
       'base hook' => 'paragraph'
     ],


### PR DESCRIPTION
Add ubc_paragraph__card template suggestion back in so that existing templates in the theme are still supported.

Standalone template is no longer provided by module